### PR TITLE
fix: add subpixel dot calc, marquee regression

### DIFF
--- a/src/InfiniteCanvas.audio.test.tsx
+++ b/src/InfiniteCanvas.audio.test.tsx
@@ -1,5 +1,5 @@
-import { act, fireEvent, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import {
   dropFiles,
   getCanvasContainer,
@@ -10,14 +10,14 @@ import {
   mockCanvasRect,
   renderCanvas,
   save,
-  setViewportSize
-} from './test/infiniteCanvasHarness';
+  setViewportSize,
+} from "./test/infiniteCanvasHarness";
 
-describe('InfiniteCanvas audio and export workflows', () => {
-  it('enables clip audio from the video frame action and controls volume from the HUD', async () => {
+describe("InfiniteCanvas audio and export workflows", () => {
+  it("enables clip audio from the video frame action and controls volume from the HUD", async () => {
     const videoPath = new URL(
-      '../fixtures/generated-lod-test-1080p.mp4',
-      import.meta.url
+      "../fixtures/generated-lod-test-1080p.mp4",
+      import.meta.url,
     ).pathname;
 
     setViewportSize({ width: 3000 });
@@ -25,41 +25,44 @@ describe('InfiniteCanvas audio and export workflows', () => {
     await dropFiles([videoPath]);
 
     await waitFor(() => {
-      expect(document.querySelector('video.media-content')).toBeInTheDocument();
+      expect(document.querySelector("video.media-content")).toBeInTheDocument();
     });
 
     const video = getMediaVideo();
     expect(video.muted).toBe(true);
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /enable audio playback/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /enable audio playback/i }),
+      );
     });
 
-    const slider = await screen.findByRole('slider', {
-      name: /volume for generated-lod-test-1080p\.mp4/i
-    }) as HTMLInputElement;
+    const slider = (await screen.findByRole("slider", {
+      name: /volume for generated-lod-test-1080p\.mp4/i,
+    })) as HTMLInputElement;
 
-    expect(screen.getAllByText('generated-lod-test-1080p.mp4').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("generated-lod-test-1080p.mp4").length,
+    ).toBeGreaterThan(0);
     await waitFor(() => {
       expect(video.muted).toBe(false);
       expect(video.volume).toBeCloseTo(0.8);
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /mute audio/i }));
+      fireEvent.click(screen.getByRole("button", { name: /mute audio/i }));
     });
 
     await waitFor(() => {
       expect(video.muted).toBe(true);
       expect(video.volume).toBeCloseTo(0.8);
     });
-    expect(screen.getByRole('button', { name: /unmute audio/i })).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    );
+    expect(
+      screen.getByRole("button", { name: /unmute audio/i }),
+    ).toHaveAttribute("aria-pressed", "true");
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /unmute audio/i }));
+      fireEvent.click(screen.getByRole("button", { name: /unmute audio/i }));
     });
 
     await waitFor(() => {
@@ -68,7 +71,7 @@ describe('InfiniteCanvas audio and export workflows', () => {
     });
 
     await act(async () => {
-      fireEvent.change(slider, { target: { value: '0.25' } });
+      fireEvent.change(slider, { target: { value: "0.25" } });
     });
 
     await waitFor(() => {
@@ -77,7 +80,7 @@ describe('InfiniteCanvas audio and export workflows', () => {
     });
 
     await act(async () => {
-      fireEvent.change(slider, { target: { value: '0' } });
+      fireEvent.change(slider, { target: { value: "0" } });
     });
 
     await waitFor(() => {
@@ -86,256 +89,271 @@ describe('InfiniteCanvas audio and export workflows', () => {
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /disable audio playback/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /disable audio playback/i }),
+      );
     });
 
     await waitFor(() => {
-      expect(screen.queryByRole('slider', {
-        name: /volume for generated-lod-test-1080p\.mp4/i
-      })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("slider", {
+          name: /volume for generated-lod-test-1080p\.mp4/i,
+        }),
+      ).not.toBeInTheDocument();
       expect(video.muted).toBe(true);
     });
   });
 
-  it('exports the selected video with the current A/B loop range', async () => {
+  it("exports the selected video with the current A/B loop range", async () => {
     const videoPath = new URL(
-      '../fixtures/generated-lod-test-1080p.mp4',
-      import.meta.url
+      "../fixtures/generated-lod-test-1080p.mp4",
+      import.meta.url,
     ).pathname;
     let currentTime = 0;
 
     setViewportSize({ width: 3000 });
-    vi.mocked(save).mockResolvedValue('/exports/generated-lod-test-1080p');
+    vi.mocked(save).mockResolvedValue("/exports/generated-lod-test-1080p");
     renderCanvas();
     await dropFiles([videoPath]);
 
     await waitFor(() => {
-      expect(document.querySelector('video.media-content')).toBeInTheDocument();
+      expect(document.querySelector("video.media-content")).toBeInTheDocument();
     });
 
     const video = getMediaVideo();
-    Object.defineProperty(video, 'duration', {
+    Object.defineProperty(video, "duration", {
       configurable: true,
-      get: () => 8
+      get: () => 8,
     });
-    Object.defineProperty(video, 'currentTime', {
+    Object.defineProperty(video, "currentTime", {
       configurable: true,
       get: () => currentTime,
       set: (value) => {
         currentTime = value;
-      }
+      },
     });
 
     fireEvent.loadedMetadata(video);
     currentTime = 2;
     fireEvent.timeUpdate(video);
-    fireEvent.click(screen.getByRole('button', { name: /set loop a point/i }));
+    fireEvent.click(screen.getByRole("button", { name: /set loop a point/i }));
     currentTime = 5;
     fireEvent.timeUpdate(video);
-    fireEvent.click(screen.getByRole('button', { name: /set loop b point/i }));
+    fireEvent.click(screen.getByRole("button", { name: /set loop b point/i }));
 
     const mediaItem = getMediaItem();
     await act(async () => {
-      fireEvent.pointerDown(mediaItem, { button: 0, clientX: 0, clientY: 0, pointerId: 21 });
+      fireEvent.pointerDown(mediaItem, {
+        button: 0,
+        clientX: 0,
+        clientY: 0,
+        pointerId: 21,
+      });
       fireEvent.pointerUp(mediaItem, { pointerId: 21 });
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /export selected video/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /export selected video/i }),
+      );
     });
 
     expect(save).toHaveBeenCalledWith({
-      title: 'Export video',
-      defaultPath: 'generated-lod-test-1080p.mp4',
+      title: "Export video",
+      defaultPath: "generated-lod-test-1080p.mp4",
       filters: [
         {
-          name: 'MP4 Video',
-          extensions: ['mp4']
-        }
-      ]
+          name: "MP4 Video",
+          extensions: ["mp4"],
+        },
+      ],
     });
     await waitFor(() => {
-      expect(invoke).toHaveBeenCalledWith('export_video', {
+      expect(invoke).toHaveBeenCalledWith("export_video", {
         path: videoPath,
-        outputPath: '/exports/generated-lod-test-1080p.mp4',
+        outputPath: "/exports/generated-lod-test-1080p.mp4",
         crop: {
           x: 0,
           y: 0,
           width: 1,
           height: 1,
           boxWidth: 1280,
-          boxHeight: 720
+          boxHeight: 720,
         },
         startTime: 2,
-        endTime: 5
+        endTime: 5,
       });
     });
   });
 
-  it('selects the active audio video from the HUD filename without changing its casing', async () => {
-    const videoPath = '/path/to/My Clip.MP4';
+  it("selects the active audio video from the HUD filename without changing its casing", async () => {
+    const videoPath = "/path/to/My Clip.MP4";
 
     renderCanvas();
     await dropFiles([videoPath]);
 
     await waitFor(() => {
-      expect(document.querySelector('video.media-content')).toBeInTheDocument();
+      expect(document.querySelector("video.media-content")).toBeInTheDocument();
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /enable audio playback/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /enable audio playback/i }),
+      );
     });
 
-    expect(screen.getAllByText('My Clip.MP4').length).toBeGreaterThan(0);
-    expect(screen.queryByText('MY CLIP.MP4')).not.toBeInTheDocument();
+    expect(screen.getAllByText("My Clip.MP4").length).toBeGreaterThan(0);
+    expect(screen.queryByText("MY CLIP.MP4")).not.toBeInTheDocument();
 
     const mediaItem = getMediaItem();
-    expect(mediaItem).toHaveClass('selected');
+    expect(mediaItem).toHaveClass("selected");
 
     const containerEl = getCanvasContainer();
     mockCanvasRect(containerEl);
 
     await act(async () => {
-      fireEvent.pointerDown(containerEl, { button: 0, clientX: 10, clientY: 10, pointerId: 13 });
+      fireEvent.pointerDown(containerEl, {
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+        pointerId: 13,
+      });
       fireEvent.pointerUp(containerEl, { pointerId: 13 });
     });
 
-    expect(mediaItem).not.toHaveClass('selected');
+    expect(mediaItem).not.toHaveClass("selected");
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /audio clip: My Clip\.MP4/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /audio clip: My Clip\.MP4/i }),
+      );
     });
 
-    expect(mediaItem).toHaveClass('selected');
+    expect(mediaItem).toHaveClass("selected");
   });
 
-  it('keeps active audio video mounted when it is outside the culling window', async () => {
+  it("keeps active audio video mounted when it is outside the culling window", async () => {
     setViewportSize({ width: 1000 });
     renderCanvas();
-    await dropFiles(['/path/to/audio-video.mp4']);
+    await dropFiles(["/path/to/audio-video.mp4"]);
 
     await waitFor(() => {
-      expect(document.querySelector('video.media-content')).toBeInTheDocument();
+      expect(document.querySelector("video.media-content")).toBeInTheDocument();
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /enable audio playback/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /enable audio playback/i }),
+      );
     });
 
     const containerEl = getCanvasContainer();
     await act(async () => {
-      fireEvent.pointerDown(containerEl, { button: 1, clientX: 0, clientY: 0, pointerId: 14 });
+      fireEvent.pointerDown(containerEl, {
+        button: 1,
+        clientX: 0,
+        clientY: 0,
+        pointerId: 14,
+      });
     });
     await act(async () => {
-      fireEvent.pointerMove(containerEl, { clientX: 10000, clientY: 0, pointerId: 14 });
+      fireEvent.pointerMove(containerEl, {
+        clientX: 10000,
+        clientY: 0,
+        pointerId: 14,
+      });
     });
     await act(async () => {
       fireEvent.pointerUp(containerEl, { pointerId: 14 });
     });
 
-    expect(document.querySelector('video.media-content')).toBeInTheDocument();
-    expect(screen.getByRole('slider', { name: /volume for audio-video\.mp4/i })).toBeInTheDocument();
+    expect(document.querySelector("video.media-content")).toBeInTheDocument();
+    expect(
+      screen.getByRole("slider", { name: /volume for audio-video\.mp4/i }),
+    ).toBeInTheDocument();
   });
 
-  it('pans the canvas to fully show the active audio video when its HUD filename is clicked', async () => {
+  it("pans the canvas to fully show the active audio video when its HUD filename is clicked", async () => {
     setViewportSize({ width: 2000, height: 1200 });
     renderCanvas();
-    await dropFiles(['/path/to/pan-target.mp4']);
+    await dropFiles(["/path/to/pan-target.mp4"]);
 
     await waitFor(() => {
-      expect(document.querySelector('video.media-content')).toBeInTheDocument();
+      expect(document.querySelector("video.media-content")).toBeInTheDocument();
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /enable audio playback/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /enable audio playback/i }),
+      );
     });
 
     const containerEl = getCanvasContainer();
     const world = getCanvasWorld();
     await act(async () => {
-      fireEvent.pointerDown(containerEl, { button: 1, clientX: 0, clientY: 0, pointerId: 15 });
+      fireEvent.pointerDown(containerEl, {
+        button: 1,
+        clientX: 0,
+        clientY: 0,
+        pointerId: 15,
+      });
     });
     await act(async () => {
-      fireEvent.pointerMove(containerEl, { clientX: -1500, clientY: -1000, pointerId: 15 });
+      fireEvent.pointerMove(containerEl, {
+        clientX: -1500,
+        clientY: -1000,
+        pointerId: 15,
+      });
     });
     await act(async () => {
       fireEvent.pointerUp(containerEl, { pointerId: 15 });
     });
 
-    expect(world.style.transform).toContain('translate(-1500px, -1000px)');
+    expect(world.style.transform).toContain("translate(-1500px, -1000px)");
 
     const animationFrames: FrameRequestCallback[] = [];
     let animationFrameHandle = 0;
     const requestAnimationFrameSpy = vi
-      .spyOn(window, 'requestAnimationFrame')
+      .spyOn(window, "requestAnimationFrame")
       .mockImplementation((callback) => {
-        if (callback.name === 'tick') {
+        if (callback.name === "tick") {
           animationFrames.push(callback);
         }
         animationFrameHandle += 1;
         return animationFrameHandle;
       });
     const cancelAnimationFrameSpy = vi
-      .spyOn(window, 'cancelAnimationFrame')
+      .spyOn(window, "cancelAnimationFrame")
       .mockImplementation(() => {});
     const performanceNowSpy = vi
-      .spyOn(performance, 'now')
+      .spyOn(performance, "now")
       .mockImplementation(() => 0);
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /audio clip: pan-target\.mp4/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /audio clip: pan-target\.mp4/i }),
+      );
     });
 
-    expect(document.querySelector('.media-item')).toHaveClass('selected');
-    expect(world.style.transform).toContain('translate(-1500px, -1000px)');
+    expect(document.querySelector(".media-item")).toHaveClass("selected");
+    expect(world.style.transform).toContain("translate(-1500px, -1000px)");
     expect(animationFrames).toHaveLength(1);
 
     await act(async () => {
       animationFrames.shift()?.(1);
     });
 
-    expect(world.style.transform).not.toContain('translate(-1500px, -1000px)');
-    expect(world.style.transform).not.toContain('translate(-950px, -502px)');
+    expect(world.style.transform).not.toContain("translate(-1500px, -1000px)");
+    expect(world.style.transform).not.toContain("translate(-950px, -502px)");
 
     await act(async () => {
       animationFrames.shift()?.(1000);
     });
 
-    expect(world.style.transform).toContain('translate(-950px, -502px)');
+    expect(world.style.transform).toContain("translate(-950px, -502px)");
 
     requestAnimationFrameSpy.mockRestore();
     cancelAnimationFrameSpy.mockRestore();
     performanceNowSpy.mockRestore();
-  });
-
-  it('uses a generated video thumbnail as the audio HUD clip tile', async () => {
-    const heavyVideoPath = new URL(
-      '../fixtures/heavy_video.mkv',
-      import.meta.url
-    ).pathname;
-
-    setViewportSize({ width: 3000 });
-    renderCanvas();
-    await dropFiles([heavyVideoPath]);
-
-    await waitFor(() => {
-      expect(document.querySelector('.video-load-thumbnail')).toHaveAttribute(
-        'src',
-        'asset:///tmp/heavy-thumb.jpg'
-      );
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /enable audio playback/i }));
-    });
-
-    expect(
-      await screen.findByRole('slider', { name: /volume for heavy_video\.mkv/i })
-    ).toBeInTheDocument();
-    expect(document.querySelector('.hud-audio-thumbnail')).toHaveAttribute(
-      'src',
-      'asset:///tmp/heavy-thumb.jpg'
-    );
-    expect(getMediaVideo()).toHaveAttribute('src', `asset://${heavyVideoPath}`);
   });
 });

--- a/src/InfiniteCanvas.tsx
+++ b/src/InfiniteCanvas.tsx
@@ -43,8 +43,9 @@ import {
 } from "./components/CanvasActions";
 import { useTauriDrop } from "./utils/drag";
 import { useCanvasHotkeys } from "./utils/keyboard";
-import { useSettingsStore } from "./stores/useSettingsStore";
-import { useAudioPlaybackStore } from "./stores/useAudioPlaybackStore";
+import { useGetSettingsStore } from "./stores/useSettingsStore";
+import { useAudioPlayback } from "./stores/useAudioPlaybackStore";
+import { drawCanvasBackground } from "./components/CanvasBackground";
 import { useBackgroundCanvas } from "./components/useBackgroundCanvas";
 import {
   getStoredVideoLoop,
@@ -56,9 +57,7 @@ import { getExportDefaultPath } from "./utils/exportPaths";
 import { getViewBounds } from "./utils/viewport";
 import { getLoopRange } from "./utils/videoUtils";
 import { notify } from "./utils/notifications";
-
-const ACTION_SELECTORS =
-  ".reset-btn, .delete-btn, .crop-btn, .reveal-btn, .screenshot-btn, .audio-btn";
+import { ACTION_SELECTORS } from "./utils/press";
 
 export default function InfiniteCanvas() {
   const [items, setItems] = useState<MediaItem[]>([]);
@@ -74,20 +73,15 @@ export default function InfiniteCanvas() {
     width: window.innerWidth,
     height: window.innerHeight,
   }));
-  const screenshotDirectory = useSettingsStore(
-    (state) => state.screenshotDirectory,
-  );
-  const canvasBackgroundPattern = useSettingsStore(
-    (state) => state.canvasBackgroundPattern,
-  );
-  const setScreenshotDirectory = useSettingsStore(
-    (state) => state.setScreenshotDirectory,
-  );
-  const activeAudioItemId = useAudioPlaybackStore(
-    (state) => state.activeItemId,
-  );
-  const toggleAudioItem = useAudioPlaybackStore((state) => state.toggleItem);
-  const clearAudioItem = useAudioPlaybackStore((state) => state.clearItem);
+
+  const {
+    screenshotDirectory,
+    setScreenshotDirectory,
+    canvasBackgroundPattern,
+  } = useGetSettingsStore();
+  const { toggleAudioItem, clearAudioItem, activeAudioItemId } =
+    useAudioPlayback();
+
   const exportingItemId = useVideoExportStore((state) => state.exportingItemId);
   const setExportingItemId = useVideoExportStore(
     (state) => state.setExportingItemId,
@@ -106,6 +100,10 @@ export default function InfiniteCanvas() {
   itemsRef.current = items;
   const selectedItemsRef = useRef(selectedItems);
   selectedItemsRef.current = selectedItems;
+  const canvasSizeRef = useRef(canvasSize);
+  canvasSizeRef.current = canvasSize;
+  const canvasBackgroundPatternRef = useRef(canvasBackgroundPattern);
+  canvasBackgroundPatternRef.current = canvasBackgroundPattern;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const backgroundCanvasRef = useRef<HTMLCanvasElement>(null);
@@ -117,9 +115,21 @@ export default function InfiniteCanvas() {
   const cropHandleRef = useRef<CropHandle | null>(null);
   const cropStartRef = useRef<TCropStart>(null);
 
+  const redrawBackgroundCanvas = useCallback((nextViewport: Viewport) => {
+    const canvas = backgroundCanvasRef.current;
+    if (!canvas) return;
+
+    drawCanvasBackground(canvas, {
+      canvasSize: canvasSizeRef.current,
+      pattern: canvasBackgroundPatternRef.current,
+      viewport: nextViewport,
+    });
+  }, []);
+
   // Canvas integrations.
   const { requestThumbnail } = useThumbnailQueue(setItems);
   const { cancelViewportAnimation, panViewportTo } = useViewportAnimation({
+    onViewportChange: redrawBackgroundCanvas,
     viewportRef,
     setViewport,
   });
@@ -212,6 +222,8 @@ export default function InfiniteCanvas() {
     }
     if (data.viewport) {
       cancelViewportAnimation();
+      viewportRef.current = data.viewport;
+      redrawBackgroundCanvas(data.viewport);
       setViewport(data.viewport);
     }
     setSelectedItems(new Set());
@@ -267,18 +279,27 @@ export default function InfiniteCanvas() {
     }
 
     if (isPanning && startDragRef.current) {
-      const dx = (e.clientX - startDragRef.current.x) / viewport.zoom;
-      const dy = (e.clientY - startDragRef.current.y) / viewport.zoom;
+      const currentViewport = viewportRef.current;
+      const dx = (e.clientX - startDragRef.current.x) / currentViewport.zoom;
+      const dy = (e.clientY - startDragRef.current.y) / currentViewport.zoom;
+      const nextViewport = {
+        ...currentViewport,
+        x: currentViewport.x + dx,
+        y: currentViewport.y + dy,
+      };
 
-      setViewport((prev) => ({ ...prev, x: prev.x + dx, y: prev.y + dy }));
+      viewportRef.current = nextViewport;
+      redrawBackgroundCanvas(nextViewport);
+      setViewport(nextViewport);
       startDragRef.current = { x: e.clientX, y: e.clientY };
     } else if (selectionBox && containerRef.current) {
       const rect = containerRef.current.getBoundingClientRect();
       const clientX = e.clientX - rect.left;
       const clientY = e.clientY - rect.top;
+      const currentViewport = viewportRef.current;
       const toWorld = (cx: number, cy: number) => ({
-        x: cx / viewport.zoom - viewport.x,
-        y: cy / viewport.zoom - viewport.y,
+        x: cx / currentViewport.zoom - currentViewport.x,
+        y: cy / currentViewport.zoom - currentViewport.y,
       });
 
       setSelectionBox((prev) =>
@@ -333,12 +354,15 @@ export default function InfiniteCanvas() {
   const handleWheel = (e: ReactWheelEvent) => {
     e.preventDefault();
     cancelViewportAnimation();
+    const currentViewport = viewportRef.current;
     const data =
       getWheelInputType(e) === "trackpad-pan"
-        ? handlePanAction({ e, viewport })
-        : handleZoomAction({ e, viewport, containerRef });
+        ? handlePanAction({ e, viewport: currentViewport })
+        : handleZoomAction({ e, viewport: currentViewport, containerRef });
 
     if (data) {
+      viewportRef.current = data;
+      redrawBackgroundCanvas(data);
       setViewport(data);
     }
   };
@@ -430,8 +454,9 @@ export default function InfiniteCanvas() {
     const dragStart = startDragRef.current;
     if (!dragStart) return;
 
-    const dx = (e.clientX - dragStart.x) / viewport.zoom;
-    const dy = (e.clientY - dragStart.y) / viewport.zoom;
+    const currentViewport = viewportRef.current;
+    const dx = (e.clientX - dragStart.x) / currentViewport.zoom;
+    const dy = (e.clientY - dragStart.y) / currentViewport.zoom;
 
     if (draggingItem === id) {
       setItems((prev) =>

--- a/src/components/CanvasBackground.test.ts
+++ b/src/components/CanvasBackground.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getCanvasBackgroundStyle } from "./CanvasBackground";
+
+describe("getCanvasBackgroundStyle", () => {
+  afterEach(() => {
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 1,
+    });
+  });
+
+  it("keeps dot spacing locked to world-space zoom", () => {
+    const canvasSize = { width: 3840, height: 2160 };
+
+    for (const zoom of [0.2, 1, 5]) {
+      const style = getCanvasBackgroundStyle({
+        canvasSize,
+        pattern: "dots",
+        viewport: { x: 1234, y: -567, zoom },
+      });
+      const screenSpacing = Number.parseFloat(
+        String(style.backgroundSize).split("px")[0],
+      );
+
+      expect(style.transform).toContain("translate3d");
+      expect(style.transform).not.toContain("scale");
+      expect(screenSpacing).toBeCloseTo(50 * zoom);
+      expect(Number.parseFloat(String(style.width))).toBeCloseTo(
+        canvasSize.width + screenSpacing * 2,
+      );
+      expect(Number.parseFloat(String(style.height))).toBeCloseTo(
+        canvasSize.height + screenSpacing * 2,
+      );
+    }
+  });
+
+  it("uses the far grid when zoomed out beyond useful dot density", () => {
+    const style = getCanvasBackgroundStyle({
+      canvasSize: { width: 3840, height: 2160 },
+      pattern: "dots",
+      viewport: { x: 1234, y: -567, zoom: 0.05 },
+    });
+
+    expect(style.backgroundImage).toContain("linear-gradient");
+    expect(style.backgroundSize).toBe("100px 100px");
+  });
+
+  it("changes dot spacing continuously during trackpad-scale zoom steps", () => {
+    const canvasSize = { width: 3840, height: 2160 };
+    const zoomSteps = Array.from(
+      { length: 120 },
+      (_, index) => 0.2 + index * 0.02,
+    );
+    let previousSpacing: number | null = null;
+
+    for (const zoom of zoomSteps) {
+      const style = getCanvasBackgroundStyle({
+        canvasSize,
+        pattern: "dots",
+        viewport: { x: 1234, y: -567, zoom },
+      });
+      const screenSpacing = Number.parseFloat(
+        String(style.backgroundSize).split("px")[0],
+      );
+
+      if (previousSpacing !== null) {
+        expect(Math.abs(screenSpacing - previousSpacing)).toBeLessThanOrEqual(
+          1.000001,
+        );
+      }
+
+      previousSpacing = screenSpacing;
+    }
+  });
+
+  it("leaves structural spacing unsnapped and snaps only the final transform", () => {
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 2,
+    });
+
+    const style = getCanvasBackgroundStyle({
+      canvasSize: { width: 3840, height: 2160 },
+      pattern: "dots",
+      viewport: { x: 1, y: 1, zoom: 0.333 },
+    });
+    const screenSpacing = Number.parseFloat(
+      String(style.backgroundSize).split("px")[0],
+    );
+
+    expect(screenSpacing).toBeCloseTo(50 * 0.333);
+    expect(screenSpacing).not.toBeCloseTo(16.5);
+    expect(style.transform).toBe("translate3d(-24.5px, -24.5px, 0)");
+  });
+});

--- a/src/components/CanvasBackground.tsx
+++ b/src/components/CanvasBackground.tsx
@@ -1,108 +1,280 @@
+import type { CSSProperties } from "react";
+import type { CanvasBackgroundPattern } from "@/stores/useSettingsStore";
 import { positiveModulo } from "@/utils/math";
-import { Viewport } from "@/utils/media.types";
+import type { Viewport } from "@/utils/media.types";
+
+// ─── Dot grid ────────────────────────────────────────────────────────────────
+const DOT_GRID_BASE_SIZE = 50;
+const DOT_GRID_MIN_VISIBLE_SCREEN_SIZE = 8;
+const DOT_GRID_FULL_OPACITY_SCREEN_SIZE = 18;
+const DOT_GRID_WORLD_RADIUS = 2;
+
+// ─── Line grid (normal zoom) ──────────────────────────────────────────────────
+const LINE_GRID_WORLD_SIZE = 500;
+const LINE_GRID_MIN_SCREEN_SIZE = 96;
+const LINE_GRID_MAX_SCREEN_SIZE = 320;
+
+// ─── Far-zoom line grid (replaces empty background when fully zoomed out) ─────
+// Activates when dot spacing falls below this screen-pixel threshold.
+const FAR_GRID_DOT_FADE_SCREEN_SIZE = DOT_GRID_MIN_VISIBLE_SCREEN_SIZE; // 8px
+const FAR_GRID_WORLD_SIZE = 500; // world units between far-grid lines
+const FAR_GRID_MAX_OPACITY = 0.1; // kept very low – thin, minimalist
+
+const SAFE_MIN_ZOOM = 0.001;
+
+// ─── Sub-pixel jitter fix ─────────────────────────────────────────────────────
+// Keep structural grid math exact and only snap the final layer translation to
+// physical display pixels. Snapping tile sizes causes phase jumps during
+// trackpad micro-zoom events on HiDPI / ProMotion displays.
+const getDpr = () => {
+  if (typeof window === "undefined") return 1;
+
+  const dpr = window.devicePixelRatio || 1;
+  return Number.isFinite(dpr) && dpr > 0 ? dpr : 1;
+};
+
+const snapToDevicePx = (v: number) => {
+  const dpr = getDpr();
+  return Math.round(v * dpr) / dpr;
+};
+
+type CanvasSize = { width: number; height: number };
+type CanvasBackgroundStyleOptions = {
+  canvasSize: CanvasSize;
+  pattern: CanvasBackgroundPattern;
+  viewport: Viewport;
+};
+
+type FarGridGeometry = {
+  alpha: number;
+  screenSize: number;
+};
+
+// ─── SVG helpers ──────────────────────────────────────────────────────────────
+const svgBg = (svg: string) =>
+  `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
+
+// Corner-plus markers for the normal line grid
+const LINE_GRID_PLUS_IMAGE = svgBg(`
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="${LINE_GRID_WORLD_SIZE}" height="${LINE_GRID_WORLD_SIZE}"
+     viewBox="0 0 ${LINE_GRID_WORLD_SIZE} ${LINE_GRID_WORLD_SIZE}">
+  <path d="M0 0V14M0 0H14M500 0V14M486 0H500M0 486V500M0 500H14M500 486V500M486 500H500"
+        stroke="#f8fafc" stroke-opacity="0.58" stroke-width="8"
+        stroke-linecap="round"/>
+</svg>`);
+
+// Thin line grid used at far zoom; alpha is baked in via CSS, not the SVG.
+// We use a single-pixel SVG cross so it tiles cleanly at any screen size.
+const makeFarGridImage = (alpha: number) => {
+  const color = `rgba(248,250,252,${alpha.toFixed(3)})`;
+  return [
+    `linear-gradient(to right, ${color} 1px, transparent 1px)`,
+    `linear-gradient(to bottom, ${color} 1px, transparent 1px)`,
+  ].join(", ");
+};
+
+// ─── Line grid sizing ─────────────────────────────────────────────────────────
+const getLineGridWorldSize = (zoom: number) => {
+  let size = LINE_GRID_WORLD_SIZE;
+  while (size * zoom < LINE_GRID_MIN_SCREEN_SIZE) size *= 2;
+  while (size * zoom > LINE_GRID_MAX_SCREEN_SIZE) size /= 2;
+  return size;
+};
+
+const getPatternWorldSize = (pattern: CanvasBackgroundPattern, zoom: number) =>
+  pattern === "dots" ? DOT_GRID_BASE_SIZE : getLineGridWorldSize(zoom);
+
+// ─── Dot opacity / image ──────────────────────────────────────────────────────
+const getDotOpacity = (screenSpacing: number) => {
+  if (screenSpacing <= DOT_GRID_MIN_VISIBLE_SCREEN_SIZE) return 0;
+  if (screenSpacing >= DOT_GRID_FULL_OPACITY_SCREEN_SIZE) return 1;
+  return (
+    (screenSpacing - DOT_GRID_MIN_VISIBLE_SCREEN_SIZE) /
+    (DOT_GRID_FULL_OPACITY_SCREEN_SIZE - DOT_GRID_MIN_VISIBLE_SCREEN_SIZE)
+  );
+};
+
+const getDotBackgroundImage = (zoom: number, screenSpacing: number) => {
+  const opacity = getDotOpacity(screenSpacing);
+  if (opacity === 0) return null; // signal to caller: dots invisible
+
+  const solidStop = Math.max(0.75, DOT_GRID_WORLD_RADIUS * zoom);
+  const transparentStop = solidStop + 0.45;
+  return `radial-gradient(circle at center, rgba(148,163,184,${(0.78 * opacity).toFixed(3)}) 0 ${solidStop}px, transparent ${transparentStop}px)`;
+};
+
+// ─── Far grid (zoomed-out thin lines) ────────────────────────────────────────
+/**
+ * When dots are invisible (screen spacing < FAR_GRID_DOT_FADE_SCREEN_SIZE),
+ * we cross-fade in a minimalist thin line grid so the canvas never feels
+ * completely empty.  The far grid uses its own world size / screen spacing so
+ * it can be tuned independently of the dot grid.
+ *
+ * Returns { image, size } or null when the far grid is fully transparent.
+ */
+const getFarGridGeometry = (
+  zoom: number,
+  dotScreenSpacing: number,
+): FarGridGeometry | null => {
+  // Opacity: 0 → FAR_GRID_MAX_OPACITY as dot spacing shrinks from
+  // FAR_GRID_DOT_FADE_SCREEN_SIZE → 0.  We invert the dot-opacity lerp.
+  const t = 1 - dotScreenSpacing / FAR_GRID_DOT_FADE_SCREEN_SIZE; // 0..1
+  if (t <= 0) return null;
+
+  const alpha = FAR_GRID_MAX_OPACITY * Math.min(t, 1);
+
+  // Pick a world size that keeps lines 80-240px apart on screen
+  let worldSize = FAR_GRID_WORLD_SIZE;
+  while (worldSize * zoom < 80) worldSize *= 2;
+  while (worldSize * zoom > 240) worldSize /= 2;
+
+  return {
+    alpha,
+    screenSize: worldSize * zoom,
+  };
+};
+
+const getFarGridLayer = (
+  zoom: number,
+  dotScreenSpacing: number,
+): { image: string; screenSize: number } | null => {
+  const geometry = getFarGridGeometry(zoom, dotScreenSpacing);
+  if (!geometry) return null;
+
+  return {
+    image: makeFarGridImage(geometry.alpha),
+    screenSize: geometry.screenSize,
+  };
+};
+
+// ─── Normal line grid image ───────────────────────────────────────────────────
+const getLineGridImage = (screenSpacing: number) => {
+  const lineAlpha = screenSpacing < 144 ? 0.1 : 0.16;
+  const c = `rgba(248,250,252,${lineAlpha})`;
+  return [
+    LINE_GRID_PLUS_IMAGE,
+    `linear-gradient(to right, ${c} 1px, transparent 1px)`,
+    `linear-gradient(to bottom, ${c} 1px, transparent 1px)`,
+  ].join(", ");
+};
+
+// ─── Pattern offset ───────────────────────────────────────────────────────────
+const getPatternOffset = (
+  pattern: CanvasBackgroundPattern,
+  screenOffset: number,
+  screenSpacing: number,
+) => {
+  const centeredDotOffset = pattern === "dots" ? screenSpacing / 2 : 0;
+  return screenOffset - screenSpacing - centeredDotOffset;
+};
+
+const snapCanvasLineToDevicePx = (v: number) => {
+  const dpr = getDpr();
+  return (Math.round(v * dpr) + 0.5) / dpr;
+};
+
+const canDrawCanvas = (
+  context: CanvasRenderingContext2D | null,
+): context is CanvasRenderingContext2D => {
+  if (!context) return false;
+
+  const candidate = context as Partial<CanvasRenderingContext2D>;
+  return (
+    typeof candidate.setTransform === "function" &&
+    typeof candidate.clearRect === "function" &&
+    typeof candidate.save === "function" &&
+    typeof candidate.restore === "function" &&
+    typeof candidate.beginPath === "function" &&
+    typeof candidate.moveTo === "function" &&
+    typeof candidate.lineTo === "function" &&
+    typeof candidate.stroke === "function" &&
+    typeof candidate.fillRect === "function"
+  );
+};
 
 export const resizeBackgroundCanvas = (
   canvas: HTMLCanvasElement,
   width: number,
   height: number,
 ) => {
-  const pixelRatio = window.devicePixelRatio || 1;
+  const pixelRatio = getDpr();
   const safeWidth = Math.max(1, width);
   const safeHeight = Math.max(1, height);
-  const pixelWidth = Math.round(safeWidth * pixelRatio);
-  const pixelHeight = Math.round(safeHeight * pixelRatio);
+  const pixelWidth = Math.ceil(safeWidth * pixelRatio);
+  const pixelHeight = Math.ceil(safeHeight * pixelRatio);
+  const styleWidth = `${safeWidth}px`;
+  const styleHeight = `${safeHeight}px`;
 
   if (canvas.width !== pixelWidth) canvas.width = pixelWidth;
   if (canvas.height !== pixelHeight) canvas.height = pixelHeight;
-  if (canvas.style.width !== `${safeWidth}px`)
-    canvas.style.width = `${safeWidth}px`;
-  if (canvas.style.height !== `${safeHeight}px`)
-    canvas.style.height = `${safeHeight}px`;
+  if (canvas.style.width !== styleWidth) canvas.style.width = styleWidth;
+  if (canvas.style.height !== styleHeight) canvas.style.height = styleHeight;
 
   return { pixelRatio, width: safeWidth, height: safeHeight };
 };
 
-export const drawDotGrid = (
+const drawGridLines = (
   context: CanvasRenderingContext2D,
   width: number,
   height: number,
   viewport: Viewport,
+  screenSpacing: number,
+  alpha: number,
 ) => {
-  const baseGridSize = 50;
-  const minGridScreenSize = 28;
-  const maxGridScreenSize = 96;
-  let dotGridSize = baseGridSize;
+  if (screenSpacing <= 0) return;
 
-  while (dotGridSize * viewport.zoom < minGridScreenSize) dotGridSize *= 2;
-  while (
-    dotGridSize > baseGridSize &&
-    dotGridSize * viewport.zoom > maxGridScreenSize
-  ) {
-    dotGridSize /= 2;
-  }
+  const zoom = Math.max(viewport.zoom, SAFE_MIN_ZOOM);
+  const startX = positiveModulo(viewport.x * zoom, screenSpacing);
+  const startY = positiveModulo(viewport.y * zoom, screenSpacing);
 
-  const spacing = dotGridSize * viewport.zoom;
-  const dotRadius = 1.35;
-  const startX = positiveModulo(viewport.x * viewport.zoom, spacing);
-  const startY = positiveModulo(viewport.y * viewport.zoom, spacing);
-
-  context.fillStyle = "#334155";
-  context.beginPath();
-  for (let y = startY; y <= height; y += spacing) {
-    for (let x = startX; x <= width; x += spacing) {
-      context.moveTo(x + dotRadius, y);
-      context.arc(x, y, dotRadius, 0, Math.PI * 2);
-    }
-  }
-  context.fill();
-};
-
-const snapCanvasLine = (value: number) => Math.round(value) + 0.5;
-
-export const drawLineGrid = (
-  context: CanvasRenderingContext2D,
-  width: number,
-  height: number,
-  viewport: Viewport,
-) => {
-  const gridWorldSize = 500;
-  const spacing = gridWorldSize * viewport.zoom;
-  if (spacing < 8) return;
-
-  const startX = positiveModulo(viewport.x * viewport.zoom, spacing);
-  const startY = positiveModulo(viewport.y * viewport.zoom, spacing);
-  const lineAlpha = spacing < 40 ? 0.09 : 0.16;
-
-  context.strokeStyle = `rgba(248, 250, 252, ${lineAlpha})`;
-  context.lineWidth = 1;
+  context.save();
+  context.strokeStyle = `rgba(248, 250, 252, ${alpha})`;
+  context.lineWidth = 1 / getDpr();
   context.beginPath();
 
-  for (let x = startX; x <= width; x += spacing) {
-    const snappedX = snapCanvasLine(x);
+  for (let x = startX; x <= width; x += screenSpacing) {
+    const snappedX = snapCanvasLineToDevicePx(x);
     context.moveTo(snappedX, 0);
     context.lineTo(snappedX, height);
   }
-  for (let y = startY; y <= height; y += spacing) {
-    const snappedY = snapCanvasLine(y);
+
+  for (let y = startY; y <= height; y += screenSpacing) {
+    const snappedY = snapCanvasLineToDevicePx(y);
     context.moveTo(0, snappedY);
     context.lineTo(width, snappedY);
   }
 
   context.stroke();
-  if (spacing < 72) return;
+  context.restore();
+};
 
-  const plusSize = Math.min(28, Math.max(12, spacing * 0.16));
+const drawLineGridPluses = (
+  context: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  viewport: Viewport,
+  screenSpacing: number,
+) => {
+  if (screenSpacing < 72) return;
+
+  const zoom = Math.max(viewport.zoom, SAFE_MIN_ZOOM);
+  const startX = positiveModulo(viewport.x * zoom, screenSpacing);
+  const startY = positiveModulo(viewport.y * zoom, screenSpacing);
+  const plusSize = Math.min(28, Math.max(12, screenSpacing * 0.16));
   const halfPlusSize = plusSize / 2;
 
-  context.strokeStyle = "rgba(248, 250, 252, 0.62)";
-  context.lineWidth = Math.min(3, Math.max(2, spacing * 0.04));
+  context.save();
+  context.strokeStyle = "rgba(248, 250, 252, 0.58)";
+  context.lineWidth = Math.min(3, Math.max(2, screenSpacing * 0.012));
   context.lineCap = "round";
   context.beginPath();
 
-  for (let y = startY; y <= height; y += spacing) {
-    const snappedY = snapCanvasLine(y);
-    for (let x = startX; x <= width; x += spacing) {
-      const snappedX = snapCanvasLine(x);
+  for (let y = startY; y <= height; y += screenSpacing) {
+    const snappedY = snapToDevicePx(y);
+
+    for (let x = startX; x <= width; x += screenSpacing) {
+      const snappedX = snapToDevicePx(x);
       context.moveTo(snappedX - halfPlusSize, snappedY);
       context.lineTo(snappedX + halfPlusSize, snappedY);
       context.moveTo(snappedX, snappedY - halfPlusSize);
@@ -111,4 +283,178 @@ export const drawLineGrid = (
   }
 
   context.stroke();
+  context.restore();
+};
+
+export const drawDotGrid = (
+  context: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  viewport: Viewport,
+) => {
+  const zoom = Math.max(viewport.zoom, SAFE_MIN_ZOOM);
+  const screenSpacing = DOT_GRID_BASE_SIZE * zoom;
+  const opacity = getDotOpacity(screenSpacing);
+
+  if (opacity <= 0) return;
+
+  const startX = positiveModulo(viewport.x * zoom, screenSpacing);
+  const startY = positiveModulo(viewport.y * zoom, screenSpacing);
+  const dotSize = 2;
+  const halfDotSize = dotSize / 2;
+
+  context.save();
+  context.fillStyle = `rgba(148, 163, 184, ${(0.78 * opacity).toFixed(3)})`;
+
+  for (let y = startY; y <= height; y += screenSpacing) {
+    const snappedY = snapToDevicePx(y - halfDotSize);
+
+    for (let x = startX; x <= width; x += screenSpacing) {
+      context.fillRect(
+        snapToDevicePx(x - halfDotSize),
+        snappedY,
+        dotSize,
+        dotSize,
+      );
+    }
+  }
+
+  context.restore();
+};
+
+export const drawLineGrid = (
+  context: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  viewport: Viewport,
+) => {
+  const zoom = Math.max(viewport.zoom, SAFE_MIN_ZOOM);
+  const screenSpacing = getLineGridWorldSize(zoom) * zoom;
+  const lineAlpha = screenSpacing < 144 ? 0.1 : 0.16;
+
+  drawGridLines(context, width, height, viewport, screenSpacing, lineAlpha);
+  drawLineGridPluses(context, width, height, viewport, screenSpacing);
+};
+
+export const drawCanvasBackground = (
+  canvas: HTMLCanvasElement,
+  { canvasSize, pattern, viewport }: CanvasBackgroundStyleOptions,
+) => {
+  const { pixelRatio, width, height } = resizeBackgroundCanvas(
+    canvas,
+    canvasSize.width,
+    canvasSize.height,
+  );
+  let context: CanvasRenderingContext2D | null = null;
+
+  try {
+    context = canvas.getContext("2d", { alpha: true });
+  } catch {
+    return;
+  }
+
+  if (!canDrawCanvas(context)) return;
+
+  context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+  context.clearRect(0, 0, width, height);
+
+  if (pattern === "dots") {
+    const zoom = Math.max(viewport.zoom, SAFE_MIN_ZOOM);
+    const dotScreenSpacing = DOT_GRID_BASE_SIZE * zoom;
+    const farGrid = getFarGridGeometry(zoom, dotScreenSpacing);
+
+    if (farGrid) {
+      drawGridLines(
+        context,
+        width,
+        height,
+        viewport,
+        farGrid.screenSize,
+        farGrid.alpha,
+      );
+    }
+
+    drawDotGrid(context, width, height, viewport);
+    return;
+  }
+
+  drawLineGrid(context, width, height, viewport);
+};
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+export const getCanvasBackgroundStyle = ({
+  canvasSize,
+  pattern,
+  viewport,
+}: CanvasBackgroundStyleOptions): CSSProperties => {
+  const zoom = Math.max(viewport.zoom, SAFE_MIN_ZOOM);
+  const patternWorldSize = getPatternWorldSize(pattern, zoom);
+
+  // Keep spacing exact so the tiled grid scales continuously without stepping.
+  const screenSpacing = patternWorldSize * zoom;
+
+  const exactOffsetX = positiveModulo(viewport.x * zoom, screenSpacing);
+  const exactOffsetY = positiveModulo(viewport.y * zoom, screenSpacing);
+
+  const offsetX = getPatternOffset(pattern, exactOffsetX, screenSpacing);
+  const offsetY = getPatternOffset(pattern, exactOffsetY, screenSpacing);
+
+  // Extend the element slightly beyond the viewport so exact fractional spacing
+  // never exposes a gap at the viewport edge.
+  const width = Math.ceil(canvasSize.width + screenSpacing * 2);
+  const height = Math.ceil(canvasSize.height + screenSpacing * 2);
+
+  // ── Build background layers ─────────────────────────────────────────────
+  let backgroundImage: string;
+  let backgroundSize: string;
+
+  if (pattern === "dots") {
+    const dotImage = getDotBackgroundImage(zoom, screenSpacing);
+
+    if (dotImage === null) {
+      // Fully zoomed out: dots invisible – try far grid
+      const far = getFarGridLayer(zoom, screenSpacing);
+      if (far) {
+        backgroundImage = far.image;
+        // Far grid has its own spacing; we embed it in a single size string.
+        // Since both layers share the same backgroundSize, pick the far size.
+        backgroundSize = `${far.screenSize}px ${far.screenSize}px`;
+      } else {
+        backgroundImage = "none";
+        backgroundSize = `${screenSpacing}px ${screenSpacing}px`;
+      }
+    } else {
+      // Normal zoom: dots visible.  Optionally blend a very faint far grid
+      // behind them for spatial reference when dots are still sparse.
+      const far = getFarGridLayer(zoom, screenSpacing);
+      if (far) {
+        // We can't mix two different backgroundSizes cleanly with shorthand,
+        // so render them as separate layers with the same primary size.
+        // The far grid image is appended last (painted first / behind).
+        backgroundImage = [dotImage, far.image].join(", ");
+        // All four layers share the dot spacing; far grid looks denser but
+        // that's fine – it just adds a subtle cross-hatch rhythm.
+        backgroundSize = `${screenSpacing}px ${screenSpacing}px`;
+      } else {
+        backgroundImage = dotImage;
+        backgroundSize = `${screenSpacing}px ${screenSpacing}px`;
+      }
+    }
+  } else {
+    // "lines" pattern – unchanged behaviour
+    backgroundImage = getLineGridImage(screenSpacing);
+    backgroundSize = `${screenSpacing}px ${screenSpacing}px`;
+  }
+
+  return {
+    // GPU compositor layer hint – keeps transforms off the main paint thread
+    willChange: "transform",
+    // Prevent sub-pixel blending artefacts on Retina/HiDPI
+    backfaceVisibility: "hidden",
+    backgroundImage,
+    backgroundSize,
+    height: `${height}px`,
+    transform: `translate3d(${snapToDevicePx(offsetX)}px, ${snapToDevicePx(offsetY)}px, 0)`,
+    width: `${width}px`,
+  };
 };

--- a/src/components/hud/HudAudioControl.tsx
+++ b/src/components/hud/HudAudioControl.tsx
@@ -8,7 +8,6 @@ type HudAudioControlProps = {
 };
 
 export function HudAudioControl({
-  activeAudioItem,
   activeAudioName,
   onSelectActiveAudioItem,
 }: HudAudioControlProps) {
@@ -16,20 +15,11 @@ export function HudAudioControl({
     useAudioPlayback();
   const audioPercent = Math.round(audioVolume * 100);
 
-  const renderAudioMarqueeItem = (isHidden = false) =>
-    activeAudioItem.thumbnailUrl ? (
-      <img
-        className="hud-audio-thumbnail"
-        src={activeAudioItem.thumbnailUrl}
-        alt={isHidden ? "" : activeAudioName}
-        aria-hidden={isHidden}
-        draggable={false}
-      />
-    ) : (
-      <span className="hud-audio-filename" aria-hidden={isHidden}>
-        {activeAudioName}
-      </span>
-    );
+  const renderAudioMarqueeItem = (isHidden = false) => (
+    <span className="hud-audio-filename" aria-hidden={isHidden}>
+      {activeAudioName}
+    </span>
+  );
 
   return (
     <div
@@ -96,4 +86,3 @@ export function HudAudioControl({
     </div>
   );
 }
-

--- a/src/components/useBackgroundCanvas.ts
+++ b/src/components/useBackgroundCanvas.ts
@@ -1,39 +1,25 @@
-import { RefObject, useEffect } from "react";
-import { Viewport } from "@/utils/media.types";
-import {
-  drawDotGrid,
-  drawLineGrid,
-  resizeBackgroundCanvas,
-} from "./CanvasBackground";
+import { type RefObject, useLayoutEffect } from "react";
+import type { CanvasBackgroundPattern } from "@/stores/useSettingsStore";
+import type { Viewport } from "@/utils/media.types";
+import { drawCanvasBackground } from "./CanvasBackground";
 
 export const useBackgroundCanvas = (
   backgroundCanvasRef: RefObject<HTMLCanvasElement | null>,
   canvasSize: { width: number; height: number },
-  canvasBackgroundPattern: string,
+  canvasBackgroundPattern: CanvasBackgroundPattern,
   viewport: Viewport,
 ) => {
-  useEffect(() => {
-    if (backgroundCanvasRef) {
-      const canvas = backgroundCanvasRef.current;
-      if (!canvas) return;
+  // Viewport motion redraws from input and animation handlers. This hook covers
+  // mount, resize, and background-pattern changes without a second paint after
+  // every React viewport commit.
+  useLayoutEffect(() => {
+    const canvas = backgroundCanvasRef.current;
+    if (!canvas) return;
 
-      const { pixelRatio, width, height } = resizeBackgroundCanvas(
-        canvas,
-        canvasSize.width,
-        canvasSize.height,
-      );
-
-      const context = canvas.getContext("2d", { alpha: true });
-      if (!context) return;
-
-      context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
-      context.clearRect(0, 0, width, height);
-
-      if (canvasBackgroundPattern === "dots") {
-        drawDotGrid(context, width, height, viewport);
-      } else {
-        drawLineGrid(context, width, height, viewport);
-      }
-    }
-  }, [canvasBackgroundPattern, canvasSize, viewport]);
+    drawCanvasBackground(canvas, {
+      canvasSize,
+      pattern: canvasBackgroundPattern,
+      viewport,
+    });
+  }, [backgroundCanvasRef, canvasBackgroundPattern, canvasSize]);
 };

--- a/src/components/useViewportAnimation.ts
+++ b/src/components/useViewportAnimation.ts
@@ -7,6 +7,7 @@ import type {
 } from "./useViewportAnimation.types";
 
 export const useViewportAnimation = ({
+  onViewportChange,
   viewportRef,
   setViewport,
 }: UseViewportAnimationParams): UseViewportAnimationResult => {
@@ -21,14 +22,16 @@ export const useViewportAnimation = ({
 
   const applyViewportPanPosition = useCallback(
     (position: ViewportPanPosition) => {
-      viewportRef.current = {
+      const nextViewport = {
         ...viewportRef.current,
         x: position.x,
         y: position.y,
       };
+      viewportRef.current = nextViewport;
+      onViewportChange?.(nextViewport);
       setViewport((prev) => ({ ...prev, x: position.x, y: position.y }));
     },
-    [setViewport, viewportRef],
+    [onViewportChange, setViewport, viewportRef],
   );
 
   const panViewportTo = useCallback(

--- a/src/components/useViewportAnimation.types.ts
+++ b/src/components/useViewportAnimation.types.ts
@@ -10,6 +10,7 @@ export type ViewportPanPosition = Pick<Viewport, "x" | "y">;
 export type UseViewportAnimationParams = {
   viewportRef: MutableRefObject<Viewport>;
   setViewport: Dispatch<SetStateAction<Viewport>>;
+  onViewportChange?: (viewport: Viewport) => void;
 };
 
 export type UseViewportAnimationResult = {

--- a/src/stores/useAudioPlaybackStore.ts
+++ b/src/stores/useAudioPlaybackStore.ts
@@ -45,4 +45,6 @@ export const useAudioPlayback = () => ({
   isAudioMuted: useAudioPlaybackStore((state) => state.muted),
   setAudioVolume: useAudioPlaybackStore((state) => state.setVolume),
   toggleAudioMuted: useAudioPlaybackStore((state) => state.toggleMuted),
+  toggleAudioItem: useAudioPlaybackStore((state) => state.toggleItem),
+  clearAudioItem: useAudioPlaybackStore((state) => state.clearItem),
 });

--- a/src/stores/useSettingsStore.ts
+++ b/src/stores/useSettingsStore.ts
@@ -74,3 +74,21 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
   },
   resetSettings: () => set(getInitialSettings()),
 }));
+
+export const useGetSettingsStore = () => {
+  const screenshotDirectory = useSettingsStore(
+    (state) => state.screenshotDirectory,
+  );
+  const canvasBackgroundPattern = useSettingsStore(
+    (state) => state.canvasBackgroundPattern,
+  );
+  const setScreenshotDirectory = useSettingsStore(
+    (state) => state.setScreenshotDirectory,
+  );
+
+  return {
+    screenshotDirectory,
+    setScreenshotDirectory,
+    canvasBackgroundPattern,
+  };
+};

--- a/src/styles/Canvas.css
+++ b/src/styles/Canvas.css
@@ -13,10 +13,10 @@
 .canvas-background {
     position: fixed;
     inset: 0;
-    width: 100dvw;
-    height: 100dvh;
     z-index: var(--z-canvas-base);
     display: block;
+    width: 100dvw;
+    height: 100dvh;
     transform: translateZ(0);
     contain: strict;
     pointer-events: none;

--- a/src/utils/press.ts
+++ b/src/utils/press.ts
@@ -1,0 +1,2 @@
+export const ACTION_SELECTORS =
+  ".reset-btn, .delete-btn, .crop-btn, .reveal-btn, .screenshot-btn, .audio-btn";


### PR DESCRIPTION
Refactor hooks, solve background lag:

- Create atomically accurate dot-background with exact grid spacing and modulo math.
- Use canvas API renderer for dots, far-grid lines, and normal grid lines.
- Background redraws now happen imperatively from pan, wheel, and kinetic animation updates via refs.
